### PR TITLE
Include Couchbase Shell in sidebar tools

### DIFF
--- a/quest.yml
+++ b/quest.yml
@@ -45,3 +45,5 @@ frameworks:
 sidebarTools:
   - name: Couchbase
     link: https://cloud.couchbase.com/
+  - name: Couchbase Shell
+    link: https://couchbase.sh/


### PR DESCRIPTION
As this quest relies a lot on the Couchbase Shell CLI, this PR adds it to the list of tool resources in the sidebar.